### PR TITLE
Added support for test.data

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -56,12 +56,19 @@ module.exports = function(grunt) {
       event: {},
       file: {},
       template: {},
-      util: {},
+      util: {}
     },
 
     // Example
     example: {
       pass: {}
+    },
+
+    // Test data
+    testData: {
+      pass: {
+        who: 'me'
+      }
     },
 
     // Linting
@@ -86,10 +93,10 @@ module.exports = function(grunt) {
   grunt.loadNpmTasks('grunt-contrib-jshint');
   grunt.loadNpmTasks('grunt-contrib-nodeunit');
   grunt.loadNpmTasks('grunt-contrib-watch');
-  
+
   // Load test bench task
   grunt.loadTasks('test');
 
   // Default: run, test, and lint
-  grunt.registerTask('default', ['testBench', 'example', 'nodeunit', 'jshint']);
+  grunt.registerTask('default', ['testBench', 'example', 'testData', 'nodeunit', 'jshint']);
 };

--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ Some of Grunt's APIs are self-contained and don't need special handling (ex: `gr
 /**
  * Creates an instance of GruntMock.
  *
- * @param {Object} config Configuration object (target, files, options).
+ * @param {Object} config Configuration object (target, files, options, data).
  * @return {GruntMock} A new instance of GruntMock.
  */
 var gruntMock = GruntMock.create(config)
@@ -134,6 +134,7 @@ gruntMock.logOk
 * `nameArgs`
 * `options`
 * `target`
+* `data`
 
 ## Notes
 

--- a/gruntMock.js
+++ b/gruntMock.js
@@ -14,7 +14,7 @@ var util = require('util');
 var grunt = require('grunt');
 
 // Implementation
-var GruntMock = function(target, files, options) {
+var GruntMock = function(target, files, options, data) {
   var self = this;
 
   // Private variables
@@ -66,6 +66,7 @@ var GruntMock = function(target, files, options) {
         files: files,
         filesSrc: [],
         flags: {},
+        data: data,
         options: function(defaults) {
           // Override defaults with options
           var result = {};
@@ -211,7 +212,7 @@ var GruntMock = function(target, files, options) {
 /**
  * Creates an instance of GruntMock.
  *
- * @param {Object} config Configuration object (target, files, options).
+ * @param {Object} config Configuration object (target, files, options, data).
  * @return {GruntMock} A new instance of GruntMock.
  */
 module.exports.create = function(config) {
@@ -219,5 +220,6 @@ module.exports.create = function(config) {
   return new GruntMock(
     config.target || '*',
     config.files || [],
-    config.options || {});
+    config.options || {},
+    config.data || {});
 };

--- a/test/testData-task.js
+++ b/test/testData-task.js
@@ -1,0 +1,13 @@
+// TestData task
+
+'use strict';
+
+module.exports = function(grunt) {
+  grunt.registerMultiTask('testData', 'Example task that uses the data attribute', function() {
+    if ('me' === this.data.who) {
+      grunt.log.ok('me');
+    } else {
+      grunt.fail.fatal('Failed because [' + this.data.who + '] is not [me]');
+    }
+  });
+};

--- a/test/testData-test.js
+++ b/test/testData-test.js
@@ -1,0 +1,61 @@
+// TestData unit tests
+
+'use strict';
+
+var gruntMock = require('../gruntMock.js');
+var testData = require('./testData-task.js');
+
+exports.testDataTest = {
+
+  pass: function(test) {
+    test.expect(4);
+    var mock = gruntMock.create({
+      target: 'pass',
+      files: [
+        {src: ['unused.txt']}
+      ],
+      options: {str: 'string', num: 1},
+      data: {who: 'me'}
+    });
+    mock.invoke(testData, function(err) {
+      test.ok(!err);
+      test.equal(mock.logOk.length, 1);
+      test.equal(mock.logOk[0], 'me');
+      test.equal(mock.logError.length, 0);
+      test.done();
+    });
+  },
+
+  fail: function(test) {
+    test.expect(2);
+    var mock = gruntMock.create({
+      target: 'fail',
+      files: [
+        {src: ['unused.txt']}
+      ],
+      options: {str: 'string', num: 1},
+      data: {who: 'someone else'}
+    });
+    mock.invoke(testData, function(err) {
+      test.ok(err);
+      test.equal(err.message, 'Failed because [someone else] is not [me]');
+      test.done();
+    });
+  },
+
+  noData: function(test) {
+    test.expect(2);
+    var mock = gruntMock.create({
+      target: 'fail',
+      files: [
+        {src: ['unused.txt']}
+      ],
+      options: {str: 'string', num: 1}
+    });
+    mock.invoke(testData, function(err) {
+      test.ok(err);
+      test.equal(err.message, 'Failed because [undefined] is not [me]');
+      test.done();
+    });
+  }
+};


### PR DESCRIPTION
In a multi task, this is the actual data stored in the Grunt config object for the given target.

@see http://gruntjs.com/api/inside-tasks#this.data